### PR TITLE
use npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/ioBroker/ioBroker.probemon"
   },
   "dependencies": {
-      "pcap": "https://github.com/mranney/node_pcap.git"
+      "pcap": "^2.0.1"
   },
   "devDependencies": {
       "grunt": "^0.4.5",


### PR DESCRIPTION
Is there any reason to use pcap 2.0.0 from git and not 2.0.1 from npm?